### PR TITLE
import force_unicode error

### DIFF
--- a/fancytree/widgets.py
+++ b/fancytree/widgets.py
@@ -3,7 +3,10 @@ from itertools import chain
 from django import forms
 from django.conf import settings
 from django.forms.widgets import Widget
-from django.utils.encoding import force_unicode
+try:
+    from django.utils.encoding import force_unicode as force_text
+except:
+    from django.utils.encoding import force_text
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.datastructures import MultiValueDict, MergeDict
@@ -69,7 +72,7 @@ class FancyTreeWidget(Widget):
             output = [u'<div></div>']
             id_attr = u''
         output.append(u'<ul class="fancytree_checkboxes"%s>' % id_attr)
-        str_values = set([force_unicode(v) for v in value])
+        str_values = set([force_text(v) for v in value])
         for i, (option_value, option_label) in enumerate(chain(self.choices, choices)):
             if has_id:
                 final_attrs = dict(final_attrs, id='%s_%s' % (attrs['id'], option_value))
@@ -78,9 +81,9 @@ class FancyTreeWidget(Widget):
                 label_for = ''
 
             cb = forms.CheckboxInput(final_attrs, check_test=lambda value: value in str_values)
-            option_value = force_unicode(option_value)
+            option_value = force_text(option_value)
             rendered_cb = cb.render(name, option_value)
-            option_label = conditional_escape(force_unicode(option_label))
+            option_label = conditional_escape(force_text(option_label))
             output.append(
                 u'<li><label%s>%s %s</label></li>' % (label_for, rendered_cb, option_label)
             )


### PR DESCRIPTION
    from fancytree.widgets import FancyTreeWidget
    File "/home/vinay/Projects/django-fancytree/fancytree/widgets.py", line 6, in <module>
    from django.utils.encoding import force_unicode
    ImportError: cannot import name 'force_unicode'